### PR TITLE
More accurate test coverage

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+exclude = migrations/*,db_create.py

--- a/project/blog/views.py
+++ b/project/blog/views.py
@@ -21,7 +21,7 @@ blog_blueprint = Blueprint(
 
 
 # routes
-@blog_blueprint.route('/blog', methods=['GET', 'POST'])  # pragma: no cover
+@blog_blueprint.route('/blog', methods=['GET', 'POST'])
 def blog():
     error = None
     form = BlogPostForm(request.form)

--- a/project/dynamic_routes/views.py
+++ b/project/dynamic_routes/views.py
@@ -1,5 +1,4 @@
-# imports
-from flask import render_template, Blueprint, abort
+from flask import render_template, Blueprint, abort   # pragma: no cover
 from project.models import Event   # pragma: no cover
 from project.models import Organization   # pragma: no cover
 from project.models import Person   # pragma: no cover

--- a/project/home/views.py
+++ b/project/home/views.py
@@ -1,6 +1,6 @@
 
 # imports
-from flask import render_template, Blueprint
+from flask import render_template, Blueprint   # pragma: no cover
 
 from project import db   # pragma: no cover
 from project.models import Person   # pragma: no cover
@@ -18,7 +18,7 @@ MAX_GRID_SIZE_HOMEPAGE_PEOPLE = 6
 
 # routes
 # use decorators to link the function to a url
-@home_blueprint.route('/', methods=['GET', 'POST'])   # pragma: no cover
+@home_blueprint.route('/', methods=['GET', 'POST'])
 def home():
     error = None
     current_person_count = db.session.query(Person).count()

--- a/project/users/views.py
+++ b/project/users/views.py
@@ -17,7 +17,7 @@ users_blueprint = Blueprint(
 
 
 # routes
-@users_blueprint.route('/login', methods=['GET', 'POST'])   # pragma: no cover
+@users_blueprint.route('/login', methods=['GET', 'POST'])
 def login():
     error = None
     form = LoginForm(request.form)
@@ -35,15 +35,15 @@ def login():
     return render_template('login.html', form=form, error=error)
 
 
-@users_blueprint.route('/logout')   # pragma: no cover
-@login_required   # pragma: no cover
+@users_blueprint.route('/logout')
+@login_required
 def logout():
     logout_user()
     return redirect(url_for('home.home'))
 
 
 @users_blueprint.route(
-    '/register/', methods=['GET', 'POST'])   # pragma: no cover
+    '/register/', methods=['GET', 'POST'])
 def register():
     form = RegisterForm()
     if form.validate_on_submit():

--- a/tests/test_dynamic_routes.py
+++ b/tests/test_dynamic_routes.py
@@ -1,0 +1,74 @@
+import unittest
+import uuid
+
+from base import BaseTestCase
+
+from project import db
+from project.models import Event
+from project.models import Organization
+from project.models import Person
+
+
+class TestDynamicRoutes(BaseTestCase):
+
+    def test_dynamic_route_event(self):
+        sample_event = str(uuid.uuid4())
+        db.session.add(
+            Event(
+                title=sample_event,
+                url_handle=sample_event,
+                description=sample_event
+            )
+        )
+        db.session.commit()
+        response = self.client.get(
+            '/' + sample_event,
+            content_type='html/text'
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(sample_event, response.data.decode('utf8'))
+
+    def test_dynamic_route_organization(self):
+        sample_organization = str(uuid.uuid4())
+        db.session.add(
+            Organization(
+                name=sample_organization,
+                url_handle=sample_organization,
+                description=sample_organization
+            )
+        )
+        db.session.commit()
+        response = self.client.get(
+            '/' + sample_organization,
+            content_type='html/text'
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(sample_organization, response.data.decode('utf8'))
+
+    def test_dynamic_route_person(self):
+        sample_person = str(uuid.uuid4())
+        db.session.add(
+            Person(
+                name=sample_person,
+                url_handle=sample_person,
+                biography=sample_person
+            )
+        )
+        db.session.commit()
+        response = self.client.get(
+            '/' + sample_person,
+            content_type='html/text'
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn(sample_person, response.data.decode('utf8'))
+
+    def test_dynamic_route_404(self):
+        sample_404 = str(uuid.uuid4())
+        response = self.client.get(
+            '/' + sample_404,
+            content_type='html/text'
+        )
+        self.assertEqual(response.status_code, 404)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
- Add tests for dynamic router. #32 
- Fix mistaken use of "pragma: no cover". Instead of suppressing the test coverage of the decorator, no cover set on the decorator skips the entire function that is being decorated. Oops! Removed those and will either research a way to get those decorators tested, or just live with slightly less than 100% coverage. #32 
- Reduces a little linter noise.