### PR TITLE
Move code coverage tool out of manager -  was missing a lot of coverage.

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,8 @@
+[report]
+exclude_lines = 
+    def __repr__
+    pragma: no cover
+    if __name__ == '__main__':
+
+[run]
+branch = True

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,6 @@ install:
   - pip install coveralls
 # command to run tests
 script:
-  - python manage.py cov
+  - coverage run -m unittest discover tests
 after_success:
   - coveralls

--- a/README.md
+++ b/README.md
@@ -75,9 +75,10 @@ Try logging in with username `admin` password `admin`
 
   `docker-compose exec web python manage.py test`
 
-- Run the test coverage report
+- Run the test coverage report (generates HTML files into coverage/ directory)
 
-  `docker-compose exec web python manage.py cov`
+  `docker-compose exec web coverage run -m unittest discover tests`
+  `docker-compose exec web coverage html -d coverage`
 
 - Run the linter(style-checker)
 

--- a/manage.py
+++ b/manage.py
@@ -18,28 +18,9 @@ manager.add_command('db', MigrateCommand)
 
 @manager.command
 def test():
-    """Runs the unit tests without coverage."""
     tests = unittest.TestLoader().discover('tests')
     unittest.TextTestRunner(verbosity=2).run(tests)
 
-
-@manager.command
-def cov():
-    """Runs the unit tests with coverage."""
-    cov = coverage.coverage(
-        branch=True,
-        include='project/*'
-    )
-    cov.start()
-    tests = unittest.TestLoader().discover('tests')
-    unittest.TextTestRunner(verbosity=2).run(tests)
-    cov.stop()
-    cov.save()
-    print('Coverage Summary:')
-    cov.report()
-    basedir = os.path.abspath(os.path.dirname(__file__))
-    covdir = os.path.join(basedir, 'coverage')
-    cov.html_report(directory=covdir)
 
 
 if __name__ == '__main__':

--- a/project/blog/views.py
+++ b/project/blog/views.py
@@ -1,23 +1,23 @@
 # imports
-from flask import request  # pragma: no cover
-from flask import render_template  # pragma: no cover
-from flask import Blueprint  # pragma: no cover
-from flask import redirect  # pragma: no cover
-from flask import url_for  # pragma: no cover
+from flask import request
+from flask import render_template
+from flask import Blueprint
+from flask import redirect
+from flask import url_for
 
-from flask.ext.login import current_user  # pragma: no cover
+from flask.ext.login import current_user
 
-from project import db  # pragma: no cover
-from project.models import BlogPost  # pragma: no cover
+from project import db
+from project.models import BlogPost
 
-from .forms import BlogPostForm  # pragma: no cover
+from .forms import BlogPostForm
 
 
 # config
 blog_blueprint = Blueprint(
     'blog', __name__,
     template_folder='templates'
-)   # pragma: no cover
+) 
 
 
 # routes

--- a/project/dynamic_routes/views.py
+++ b/project/dynamic_routes/views.py
@@ -1,13 +1,13 @@
-from flask import render_template, Blueprint, abort   # pragma: no cover
-from project.models import Event   # pragma: no cover
-from project.models import Organization   # pragma: no cover
-from project.models import Person   # pragma: no cover
+from flask import render_template, Blueprint, abort
+from project.models import Event
+from project.models import Organization
+from project.models import Person
 
 
 dynamic_routes_blueprint = Blueprint(
     'dynamic_routes', __name__,
     template_folder='templates'
-)   # pragma: no cover
+)
 
 
 # Dynamic router for nice urls example.com/billgates or example.com/barcampgb

--- a/project/events/views.py
+++ b/project/events/views.py
@@ -1,23 +1,23 @@
 # imports
-from flask import request  # pragma: no cover
-from flask import render_template  # pragma: no cover
-from flask import Blueprint  # pragma: no cover
-from flask import redirect  # pragma: no cover
-from flask import url_for  # pragma: no cover
+from flask import request
+from flask import render_template
+from flask import Blueprint
+from flask import redirect
+from flask import url_for
 
-from flask.ext.login import current_user  # pragma: no cover
+from flask.ext.login import current_user
 
-from project import db  # pragma: no cover
-from project.models import Event  # pragma: no cover
+from project import db
+from project.models import Event
 
-from .forms import EventForm  # pragma: no cover
+from .forms import EventForm
 
 
 # config
 events_blueprint = Blueprint(
     'events', __name__,
     template_folder='templates'
-)   # pragma: no cover
+) 
 
 
 # routes

--- a/project/home/views.py
+++ b/project/home/views.py
@@ -1,9 +1,9 @@
 
 # imports
-from flask import render_template, Blueprint   # pragma: no cover
+from flask import render_template, Blueprint
 
-from project import db   # pragma: no cover
-from project.models import Person   # pragma: no cover
+from project import db
+from project.models import Person
 
 import random
 
@@ -12,7 +12,7 @@ import random
 home_blueprint = Blueprint(
     'home', __name__,
     template_folder='templates'
-)   # pragma: no cover
+)
 MAX_GRID_SIZE_HOMEPAGE_PEOPLE = 6
 
 

--- a/project/organizations/views.py
+++ b/project/organizations/views.py
@@ -1,21 +1,21 @@
 # imports
-from flask import request  # pragma: no cover
-from flask import render_template  # pragma: no cover
-from flask import Blueprint  # pragma: no cover
-from flask import redirect  # pragma: no cover
-from flask import url_for  # pragma: no cover
+from flask import request
+from flask import render_template
+from flask import Blueprint
+from flask import redirect
+from flask import url_for
 
-from project import db  # pragma: no cover
-from project.models import Organization  # pragma: no cover
+from project import db
+from project.models import Organization
 
-from .forms import OrganizationForm  # pragma: no cover
+from .forms import OrganizationForm
 
 
 # config
 organizations_blueprint = Blueprint(
     'organizations', __name__,
     template_folder='templates'
-)   # pragma: no cover
+) 
 
 
 # routes

--- a/project/people/views.py
+++ b/project/people/views.py
@@ -1,23 +1,23 @@
 # imports
-from flask import request  # pragma: no cover
-from flask import render_template  # pragma: no cover
-from flask import Blueprint  # pragma: no cover
-from flask import redirect  # pragma: no cover
-from flask import url_for  # pragma: no cover
+from flask import request
+from flask import render_template
+from flask import Blueprint
+from flask import redirect
+from flask import url_for
 
-from flask.ext.login import current_user  # pragma: no cover
+from flask.ext.login import current_user
 
-from project import db  # pragma: no cover
-from project.models import Person  # pragma: no cover
+from project import db
+from project.models import Person
 
-from .forms import PersonForm  # pragma: no cover
+from .forms import PersonForm
 
 
 # config
 people_blueprint = Blueprint(
     'people', __name__,
     template_folder='templates'
-)   # pragma: no cover
+) 
 
 
 # routes

--- a/project/users/views.py
+++ b/project/users/views.py
@@ -1,19 +1,19 @@
 # imports
 from flask import redirect, render_template, request, \
-    url_for, Blueprint   # pragma: no cover
+    url_for, Blueprint
 from flask.ext.login import login_user, \
-    login_required, logout_user   # pragma: no cover
+    login_required, logout_user
 
-from .forms import LoginForm, RegisterForm   # pragma: no cover
-from project import db   # pragma: no cover
-from project.models import User, bcrypt   # pragma: no cover
+from .forms import LoginForm, RegisterForm
+from project import db
+from project.models import User, bcrypt
 
 
 # config
 users_blueprint = Blueprint(
     'users', __name__,
     template_folder='templates'
-)   # pragma: no cover
+)
 
 
 # routes


### PR DESCRIPTION
The coverage.py tool being called from within the manage.py was causing a number of inaccuracies with code coverage reporting due to the amount of code that was already loaded before the coverage tool could run.  Now the README and .travis files indicate how to run the coverage tool external to the app.

This PR also removed a bunch of no longer needed `# pragma: no cover` statements added long ago to suppress some of false negatives.

I wonder if this will screw up coveralls and travis.......